### PR TITLE
Add professional, comprehensive GitHub profile README with healthtech portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,71 @@
+<div align="center">
+  <h1>Giles Alonso — Self-Taught Healthtech Developer</h1>
+  <h3>Strategic INTJ-A mind building data-driven systems for public health impact</h3>
+  <p>
+    <img src="https://img.shields.io/badge/Focus-Healthcare%20Innovation-5a189a?style=flat-square" alt="Healthcare Innovation Badge" />
+    <img src="https://img.shields.io/badge/Path-Self%20Taught-0b7285?style=flat-square" alt="Self Taught Badge" />
+    <img src="https://img.shields.io/badge/Personality-INTJ--A-343a40?style=flat-square" alt="INTJ-A Badge" />
+  </p>
+</div>
 
+---
+
+### 👋 About me
+
+- Self-taught developer who transitioned from clinical dentistry into architecting digital healthcare operations for the public sector in Brazil.
+- I combine data analytics, automation, and policy awareness to design transparent systems that stand up to stakeholder scrutiny.
+- Strategic INTJ-A: I map constraints, align stakeholders, and deliver measurable results at pace.
+- Advocating for equitable healthcare resource allocation through purposeful technology and clear communication.
+
+### 🚀 Featured projects
+
+#### Nova PPI Capixaba (RemanejaSUS) · [Visit](https://sites.google.com/view/novappicapixaba/)
+- **Role:** Sole developer delivering the state-wide RemanejaSUS platform for the State Health Secretariat of Espírito Santo (SESA).
+- **Mission:** Manage the physical and financial reallocation of SUS resources across all municipalities with full transparency.
+- **Tech stack:** Google AppSheet · Google Sheets · Google Apps Script (automation, triggers, reporting).
+- **Key features:**
+  - Automated monthly cycles orchestrated with time-based triggers.
+  - Real-time “Living PPI” views that keep programming data accurate and auditable.
+  - Financial validation rules that prevent negative balances before approvals.
+  - Structured negotiation workflow guiding municipal managers end-to-end.
+  - Automated PDF reporting and email distribution for every reallocation cycle.
+- **Impact:** Elevates transparency, enforces equity in statewide healthcare allocation, and strengthens interfederative collaboration across Espírito Santo.
+
+#### PPI · [Visit](https://PPI.pythonanywhere.com)
+- Reliable SIGTAP reference that keeps critical Brazilian healthcare procedure data available even when official portals fail.
+- Built to support clinicians, administrators, and analysts who need quick, accurate procedure intelligence.
+
+#### Portfolio Sites
+- [solvethis.qzz.io](https://solvethis.qzz.io) — Commercial bilingual landing site for automation and AI services.
+- [React portfolio (Vercel deployment & source)](https://github.com/GilesAlonso/portfolio) — React-based showcase of projects, skills, and career narrative.
+- [IAdventures](https://gilesalonso.github.io/IAdventures) — Collection of AI experiments and tooling explorations.
+
+### 🛠️ Skills at a glance
+
+- **Data & Analytics:** Tableau _(Experienced)_ • Looker Studio _(Proficient)_ • Excel _(Highly experienced)_ • Sheets _(Experienced)_ • SQL _(Proficient)_ • Python _(Intermediate)_ • Jupyter/Colab _(Intermediate)_ • Power BI _(Familiar)_ • R _(Advanced)_ • RStudio _(Advanced)_
+- **Development & Automation:** Google Apps Script/Webhooks _(Advanced)_ • Python _(Intermediate)_ • GitHub _(Moderate)_ • Selenium _(Intermediate)_ • Bash/Shell _(Proficient)_ • PowerShell _(Proficient)_ • Batch scripting _(Proficient)_ • Markdown _(Experienced)_
+- **Operating Systems & Infrastructure:** Xubuntu/Linux Mint _(Competent)_ • HPLIP _(Experienced)_ • Windows Task Scheduler _(Experienced)_
+- **Collaboration & Productivity:** Google Workspace _(Experienced)_ • Notion _(Familiar)_ • Trello _(Familiar)_ • Asana _(Basic)_ • Miro _(Familiar)_ • LibreOffice _(Experienced)_
+- **AI & Emerging Tech:** ChatGPT _(Experienced)_ • Google AI Studio • Qwen • Manus • Kimi • Perplexity • Claude • cto.new
+- **Project Management & Strategic Frameworks:** 5W2H _(Experienced)_ • RACI _(Proficient)_ • SWOT _(Experienced)_ • Kanban _(Experienced)_ • PDCA _(Experienced)_ • SMART _(Experienced)_ • Process Mapping _(Experienced)_ • Gantt _(Familiar)_ • Stakeholder Grid _(Experienced)_ • Risk Matrix _(Familiar)_ • OKRs _(Familiar)_ • Balanced Scorecard _(Familiar)_ • Mind Mapping _(Experienced)_ • Business Model Canvas _(Familiar)_ • BPM Canvas _(Familiar)_ • Ishikawa _(Familiar)_ • Logic Model _(Familiar)_ • Value Stream Mapping _(Basic)_
+
+### 🎯 Current focus
+
+- Scaling RemanejaSUS automations with deeper scenario modeling and proactive alerting.
+- Strengthening advanced SQL and Python pipelines to support statewide healthcare analytics.
+- Evaluating practical AI copilots to accelerate decision support and reduce manual reconciliation work.
+
+### 📊 GitHub by the numbers
+
+<p align="center">
+  <img src="https://github-readme-stats.vercel.app/api?username=GilesAlonso&show_icons=true&hide_title=true&hide_border=true&theme=radical" alt="Giles' GitHub stats" />
+  <img src="https://streak-stats.demolab.com?user=GilesAlonso&theme=radical&hide_border=true" alt="Giles' GitHub streak" />
+  <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=GilesAlonso&layout=compact&hide_border=true&theme=radical" alt="Top languages" />
+</p>
+
+### 🤝 Let's connect
+
+- 💼 LinkedIn: [linkedin.com/in/gilesalonso](https://www.linkedin.com/in/gilesalonso/)
+- 📧 Email: [giles.g.alonso@gmail.com](mailto:giles.g.alonso@gmail.com)
+- 💬 Live chat: [tawk.to/solve-this](https://tawk.to/chat/640884f031ebfa0fe7f16040/1gr0keive)
+- 🌐 Portfolio hub: [solvethis.qzz.io](https://solvethis.qzz.io) · [IAdventures](https://gilesalonso.github.io/IAdventures)


### PR DESCRIPTION
### Summary
This PR introduces a new README.md for the main GitHub profile. The file showcases major healthcare and portfolio projects, skills, and professional identity with a strategic focus on self-taught public health systems engineering.

### Details
- Highlights the user's self-taught background and INTJ-A strategic approach
- Features state-level Nova PPI Capixaba (RemanejaSUS) and key open-source/portfolio projects with tech stacks and impact
- Organizes a broad set of technical, analytical, automation, AI, and management skills into scannable categories
- Includes current focus, recent technical efforts, and social/contact links
- Clean, mobile-optimized markdown with badges and GitHub stat widgets